### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Install JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: AdoptOpenJDK/install-jdk@2f15d3f82051aa50984186fc1184467d0d9f87d0 #v1
         with:
           version: 11
           architecture: x64

--- a/.github/workflows/commit_lint.yaml
+++ b/.github/workflows/commit_lint.yaml
@@ -11,4 +11,4 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v3
+      - uses: wagoid/commitlint-github-action@baffd3c16c570c0a26bf89be729b81bb796e9bd5 #v3

--- a/.github/workflows/openapi_update.yaml
+++ b/.github/workflows/openapi_update.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4 #v1
         with:
           token: ${{ env.APP_SERVICES_CI_TOKEN }}
           repository: ${{ matrix.repo }}

--- a/.github/workflows/update-apicurio-deps.yaml
+++ b/.github/workflows/update-apicurio-deps.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: Install JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: AdoptOpenJDK/install-jdk@2f15d3f82051aa50984186fc1184467d0d9f87d0 #v1
         with:
           version: 11
           architecture: x64
@@ -38,7 +38,7 @@ jobs:
           make pr-check
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 #v3
         with:
           commit-message: Update Apicurio dependencies
           title: Update Apicurio dependencies
@@ -53,7 +53,7 @@ jobs:
 
       - name: Notify of version update failure
         if: ${{ failure() }}
-        uses: Co-qn/google-chat-notification@releases/v1
+        uses: Co-qn/google-chat-notification@b9227d9daa4638c9782a5bd16c4abb86268127a1 #releases/v1
         with:
           name: ${{ github.workflow }}
           url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
